### PR TITLE
Add Continuous Integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,11 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
-      run: stack build --fast --system-ghc
+      with:
+        entrypoint: stack 
+        args: build --fast --system-ghc
     - name: Test
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
-      run: stack test --fast --system-ghc
+      with:
+        entrypoint: stack 
+        args: test --fast --system-ghc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
+      run: stack build --fast --system-ghc
+    - name: Test
+      uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
+      run: stack test --fast --system-ghc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
       with:
         entrypoint: stack
-        args: build --fast --system-ghc --stack-root /root/.stack
+        args: build --fast --system-ghc --stack-root /root/.stack --allow-different-user
     - name: Test
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
       with:
         entrypoint: stack 
-        args: test --fast --system-ghc --stack-root /root/.stack
+        args: test --fast --system-ghc --stack-root /root/.stack --allow-different-user

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,10 @@ jobs:
       with:
         entrypoint: stack 
         args: build --fast --system-ghc
+        github_workspace: /home/stackage/github
     - name: Test
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
       with:
         entrypoint: stack 
         args: test --fast --system-ghc
+        github_workspace: /home/stackage/github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,12 +12,10 @@ jobs:
     - name: Build
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
       with:
-        entrypoint: stack 
-        args: build --fast --system-ghc
-        github_workspace: /home/stackage/github
+        entrypoint: stack
+        args: build --fast --system-ghc --stack-root /root/.stack
     - name: Test
       uses: docker://earnestresearch/k8s-volume-discovery-dependencies:latest
       with:
         entrypoint: stack 
-        args: test --fast --system-ghc
-        github_workspace: /home/stackage/github
+        args: test --fast --system-ghc --stack-root /root/.stack


### PR DESCRIPTION
This PR adds CI to the repo using Github Actions.
At the moment build this takes ~8-9 minutes to complete, if we manage to reduce the "dependencies" dockerfile we'll be able to reduce it even further.